### PR TITLE
Fix restarting service when network connected

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.oneedu.connection"
         minSdkVersion 18
         targetSdkVersion 21
-        versionCode 1
-        versionName "1.0"
+        versionCode 101
+        versionName "1.0.1"
     }
     buildTypes {
         release {

--- a/app/src/main/java/org/oneedu/connection/ConnectivityChangeReceiver.java
+++ b/app/src/main/java/org/oneedu/connection/ConnectivityChangeReceiver.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
+import android.util.Log;
 
 /**
  * Created by dongseok0 on 17/03/15.
@@ -17,14 +18,16 @@ public class ConnectivityChangeReceiver extends BroadcastReceiver {
         NetworkInfo activeNetwork = connectionManager.getActiveNetworkInfo();
         boolean isConnected = activeNetwork != null && activeNetwork.isConnected();
 
+        Log.d("ConnectivityChangeReceiver", intent.toString());
         Intent i = new Intent("org.oneedu.connection.PROXY");
 
         if (isConnected) {
             WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
             android.net.wifi.WifiInfo wifiInfo = wifiManager.getConnectionInfo();
-            String ssid = wifiInfo.getSSID();
-
-            i.putExtra("SSID", ssid);
+            if (wifiInfo != null) {
+                String ssid = wifiInfo.getSSID();
+                i.putExtra("SSID", ssid);
+            }
         }
 
         context.startService(i);

--- a/app/src/main/java/org/oneedu/connection/ConnectivityChangeReceiver.java
+++ b/app/src/main/java/org/oneedu/connection/ConnectivityChangeReceiver.java
@@ -3,9 +3,6 @@ package org.oneedu.connection;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.net.wifi.WifiManager;
 import android.util.Log;
 
 /**
@@ -14,22 +11,8 @@ import android.util.Log;
 public class ConnectivityChangeReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-        ConnectivityManager connectionManager = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetwork = connectionManager.getActiveNetworkInfo();
-        boolean isConnected = activeNetwork != null && activeNetwork.isConnected();
-
         Log.d("ConnectivityChangeReceiver", intent.toString());
         Intent i = new Intent("org.oneedu.connection.PROXY");
-
-        if (isConnected) {
-            WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-            android.net.wifi.WifiInfo wifiInfo = wifiManager.getConnectionInfo();
-            if (wifiInfo != null) {
-                String ssid = wifiInfo.getSSID();
-                i.putExtra("SSID", ssid);
-            }
-        }
-
         context.startService(i);
     }
 }

--- a/app/src/main/java/org/oneedu/connection/ProxyService.java
+++ b/app/src/main/java/org/oneedu/connection/ProxyService.java
@@ -58,6 +58,14 @@ public class ProxyService extends Service {
         Preferences.init(mContext);
         PreferenceManager.getDefaultSharedPreferences(mContext).edit().putBoolean(PreferenceUtils.chainProxyEnabled, true).commit();
         PreferenceManager.getDefaultSharedPreferences(mContext).edit().putString(PreferenceUtils.proxyPort, "9008").commit();
+
+        // fix - network connected and restarting service
+        WifiManager wifiManager = (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+        android.net.wifi.WifiInfo wifiInfo = wifiManager.getConnectionInfo();
+        if (wifiInfo != null) {
+            String ssid = wifiInfo.getSSID();
+            toggleProxy(ssid);
+        }
     }
 
     @Override


### PR DESCRIPTION
Basically, proxy is activated by connectivity change broadcast. So if there is no change event, proxy is not activated.
To fix it, check network status and activate proxy during service start-up.
